### PR TITLE
fixed loading wheel in Hit navigator

### DIFF
--- a/js/components/preview/molecule/moleculeList.js
+++ b/js/components/preview/molecule/moleculeList.js
@@ -133,7 +133,7 @@ const MoleculeList = memo(
 
     // Reset Infinity scroll
     useEffect(() => {
-      setCurrentPage(0);
+      // setCurrentPage(0);
     }, [object_selection]);
 
     if (isActiveFilter) {

--- a/js/components/preview/molecule/moleculeView.js
+++ b/js/components/preview/molecule/moleculeView.js
@@ -416,7 +416,6 @@ const MoleculeView = memo(({ imageHeight, imageWidth, data }) => {
             container
             justify="flex-start"
             alignItems="flex-end"
-            a
             direction="row"
             wrap="nowrap"
             className={classes.fullHeight}


### PR DESCRIPTION
After opening a session there was an issue with infinite scroll and loading wheel display.